### PR TITLE
fix: upgrade league/commonmark to 2.10.0 (GHSA-8rr7-cvq3-gmfh)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     ]
   },
   "require": {
-    "league/commonmark": "2.9.0",
+    "league/commonmark": "2.10.0",
     "rlanvin/php-rrule": "^2.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3add01dd708f6be5dfd7f4293205f1d8",
+    "content-hash": "d578fb6d550a2c227680b9558997984c",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -83,16 +83,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
-                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -129,7 +129,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.10-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -186,7 +186,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-03T13:42:31+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
## Summary
Upgrade league/commonmark from 2.9.0 to 2.10.0 to fix GHSA-8rr7-cvq3-gmfh.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-8rr7-cvq3-gmfh |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-8rr7-cvq3-gmfh` |
| **File** | `composer.lock` (dependency: `league/commonmark`) |
| **Assessment** | Defensive hardening |

**Description**: league/commonmark: Denial of service via distinctly-named attributes in the Attributes extension

## Changes
- `composer.json`
- `composer.lock`

## Behavior Preservation
This change touches only dependency manifests (`composer.json`, `composer.lock`); no source file in the repository is modified.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=GHSA-8rr7-cvq3-gmfh scanner=trivy vuln=GHSA-8rr7-cvq3-gmfh -->
